### PR TITLE
Update thresholds

### DIFF
--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -19,7 +19,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
 
   nevents = 0;
   auto nreset{conf->Get("NRESET", 1000)};
-  nevents_reset = std::stoi(nreset);
+  nevents_reset = nreset;
   nPlanes = 19;
   block_ = conf->Get("FPGA_ID",1);
 

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -25,7 +25,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
 
   hcal_event = m_monitor->Book<TH2D>("hcal_event", "hcal_event", "", ";Plane;Bar", nPlanes+1, 0, nPlanes+1, 12, 0, 12);
   m_monitor->SetDrawOptions(hcal_event, "colz");
-  hcal_event->SetTitle("Hcal Event PEs per Bar");
+  hcal_event->SetTitle("Hcal Event: Channels Above Threshold per Bar");
   hcal_event->SetStats(0);
 
   for (int i{0}; i < 3; ++i) { //this is ROC 1 to 6

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -128,7 +128,7 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
     int channel = el.channel();
     int link = el.link();
     int inlink = el.inlink_channel();
-    int hgcroc_number = fpga*3 + roc;
+    //int hgcroc_number = fpga*3 + roc;
     int hgcroc_number = roc;
     if(std::count(unusedchans.begin(), unusedchans.end(), channel)) continue;
     //std::cout<<"fpga: "<<fpga<<"  roc: "<<roc<<"  channel: "<<channel<<"  link: "<<link<<"  inlink: "<<inlink<<"  sample size: "<<samples.size()<<std::endl;
@@ -210,7 +210,7 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
     for(int j = 0; j < 12; j++){
       std::string key0 = std::to_string(i) + ":" + std::to_string(j) + ":0";
       std::string key1 = std::to_string(i) + ":" + std::to_string(j) + ":1";
-      //double PEsum = 0;
+      double PEsum = 0;
       if(physical_map.count(key0) > 0 && physical_map.count(key1) > 0){
         PEsum = physical_map.at(key0) + physical_map.at(key1);
       }

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -18,48 +18,49 @@ void HCalTestBeamMonitor::AtConfiguration() {
   auto conf{GetConfiguration()};
 
   nevents = 0;
-  auto nreset{conf->Get("NRESET", "")};
+  auto nreset{conf->Get("NRESET", 1000)};
   nevents_reset = std::stoi(nreset);
   nPlanes = 19;
+  block_ = conf->Get("FPGA_ID",1);
 
   hcal_event = m_monitor->Book<TH2D>("hcal_event", "hcal_event", "", ";Plane;Bar", nPlanes+1, 0, nPlanes+1, 12, 0, 12);
   m_monitor->SetDrawOptions(hcal_event, "colz");
   hcal_event->SetTitle("Hcal Event PEs per Bar");
   hcal_event->SetStats(0);
-  
-  for (int i{0}; i < 6; ++i) { //this is ROC 1 to 6
-    adc_histo_map["ROC " + std::to_string(i) + " - ADC"] =
-        m_monitor->Book<TH2D>("ROC " + std::to_string(i) + " ADC",
-                              "ROC_" + std::to_string(i) + "_ADC", "",
+
+  for (int i{0}; i < 3; ++i) { //this is ROC 1 to 6
+    adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"] =
+        m_monitor->Book<TH2D>("FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " ADC",
+                              "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_ADC", "",
                               ";Channel;ADC", 72, 0, 72, 1024, 0, 1024);
-    m_monitor->SetDrawOptions(adc_histo_map["ROC " + std::to_string(i) + " - ADC"], "colz");
-    adc_histo_map["ROC " + std::to_string(i) + " - ADC"]->SetTitle(("ADC vs Channel, ROC " + std::to_string(i)).c_str());
-    adc_histo_map["ROC " + std::to_string(i) + " - ADC"]->SetStats(0);   
-    
-    tot_histo_map["ROC " + std::to_string(i) + " - TOT"] =
-        m_monitor->Book<TH2D>("ROC " + std::to_string(i) + " TOT",
-                              "ROC_" + std::to_string(i) + "_TOT", "",
+    m_monitor->SetDrawOptions(adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"], "colz");
+    adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"]->SetTitle(("ADC vs Channel, FPGA " + std::to_string(_block) +": ROC " + std::to_string(i)).c_str());
+    adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"]->SetStats(0);
+
+    tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"] =
+        m_monitor->Book<TH2D>("FPGA " + std::to_string(block_) + ":ROC " + std::to_string(i) + " TOT",
+                              "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_TOT", "",
                               ";Channel;TOT", 72, 0, 72, 1024, 0, 1024);
-    m_monitor->SetDrawOptions(tot_histo_map["ROC " + std::to_string(i) + " - TOT"], "colz");
-    tot_histo_map["ROC " + std::to_string(i) + " - TOT"]->SetTitle(("TOT vs Channel, ROC " + std::to_string(i)).c_str());
-    tot_histo_map["ROC " + std::to_string(i) + " - TOT"]->SetStats(0);   
-    
-    toa_histo_map["ROC " + std::to_string(i) + " - TOA"] =
-        m_monitor->Book<TH2D>("ROC " + std::to_string(i) + " TOA",
-                              "ROC_" + std::to_string(i) + "_TOA", "",
+    m_monitor->SetDrawOptions(tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"], "colz");
+    tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"]->SetTitle(("TOT vs Channel, FPGA " + std::to_string(_block) +": ROC " + std::to_string(i)).c_str());
+    tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"]->SetStats(0);
+
+    toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"] =
+        m_monitor->Book<TH2D>("FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " TOA",
+                              "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_TOA", "",
                               ";Channel;TOA", 72, 0, 72, 1024, 0, 1024);
-    m_monitor->SetDrawOptions(toa_histo_map["ROC " + std::to_string(i) + " - TOA"], "colz");
-    toa_histo_map["ROC " + std::to_string(i) + " - TOA"]->SetTitle(("TOA vs Channel, ROC " + std::to_string(i)).c_str());
-    toa_histo_map["ROC " + std::to_string(i) + " - TOA"]->SetStats(0);        
+    m_monitor->SetDrawOptions(toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"], "colz");
+    toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"]->SetTitle(("TOA vs Channel, FPGA " + std::to_string(_block) + ": ROC " + std::to_string(i)).c_str());
+    toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"]->SetStats(0);
 
     //hardcoded 8 time samples
-    max_sample_histo_map["ROC " + std::to_string(i) + " - max_sample"] =
-        m_monitor->Book<TH2D>("ROC " + std::to_string(i) + " max_sample",
-                              "ROC_" + std::to_string(i) + "_max_sample", "",
+    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"] =
+        m_monitor->Book<TH2D>("FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " max_sample",
+                              "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_max_sample", "",
                               ";Channel;max_sample", 72, 0, 72, 8, 0, 8);
-    m_monitor->SetDrawOptions(max_sample_histo_map["ROC " + std::to_string(i) + " - max_sample"], "colz");
-    max_sample_histo_map["ROC " + std::to_string(i) + " - max_sample"]->SetTitle(("max_sample vs Channel, ROC " + std::to_string(i)).c_str());
-    max_sample_histo_map["ROC " + std::to_string(i) + " - max_sample"]->SetStats(0);                  
+    m_monitor->SetDrawOptions(max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"], "colz");
+    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"]->SetTitle(("max_sample vs Channel, FPGA " + std::to_string(_block) + ": ROC " + std::to_string(i)).c_str());
+    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"]->SetStats(0);
   }
 
   hcalhits_top = m_monitor->Book<TH2D>("hcalhits_top", "hcalhits_top", "", ";Plane;Bar", nPlanes+1, 0, nPlanes+1, 12, 0, 12);
@@ -70,9 +71,9 @@ void HCalTestBeamMonitor::AtConfiguration() {
   hcalhits_bot->SetTitle("Hits Above Threshold Bot/Left");
   hcalhits_top->SetStats(0);
   hcalhits_bot->SetStats(0);
-  total_PE = m_monitor->Book<TH1D>("total_PE", "total_PE", "", ";PEs;", 100, 0, 1000);
-  total_PE->SetTitle("Total PEs per Event");
-  total_PE->SetStats(0);
+  //total_PE = m_monitor->Book<TH1D>("total_PE", "total_PE", "", ";PEs;", 100, 0, 1000);
+  //total_PE->SetTitle("Total PEs per Event");
+  //total_PE->SetStats(0);
   std::string daqpath = std::getenv("DAQ_INSTALL_PREFIX");
   auto daqmapfile{conf->Get("HCALDAQMAP", "")};
   auto gainfile{conf->Get("HCALGAIN", "")};
@@ -97,10 +98,9 @@ void HCalTestBeamMonitor::AtConfiguration() {
   adcgain_map = CSVParser::getADCGainMap(fullgainfile);
   totped_map = CSVParser::getTOTPedMap(fullgainfile);
   totgain_map = CSVParser::getTOTGainMap(fullgainfile);
-  block_ = conf->Get("FPGA_ID",1);
-  
+
   unusedchans = {8, 17, 26, 35, 44, 53, 62, 71, 72};
-  
+
   threshold_PE = 5.; //aribtrary for now
   energy_per_mip = 4.66; //MeV/MIP
   voltage_hcal = 5.; //mV/PE
@@ -111,15 +111,15 @@ void HCalTestBeamMonitor::AtConfiguration() {
 void HCalTestBeamMonitor::AtEventReception(EventSP event) {
   // Fill HCal plots
   auto data = hcal::decode(event->GetBlock(block_));
-  
+
   bool newSpill = nevents%nevents_reset == 0;
-  
+
   if(newSpill){
     hcal_event->Reset();
   }
-  
+
   double PE = 0;
-  
+
   std::map<std::string, double> physical_map;
 
   for (const auto& [el, samples] : data) {
@@ -129,6 +129,7 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
     int link = el.link();
     int inlink = el.inlink_channel();
     int hgcroc_number = fpga*3 + roc;
+    int hgcroc_number = roc;
     if(std::count(unusedchans.begin(), unusedchans.end(), channel)) continue;
     //std::cout<<"fpga: "<<fpga<<"  roc: "<<roc<<"  channel: "<<channel<<"  link: "<<link<<"  inlink: "<<inlink<<"  sample size: "<<samples.size()<<std::endl;
     std::string rocchan = std::to_string(fpga)+":"+std::to_string(roc) + ":" + std::to_string(channel);
@@ -178,15 +179,16 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
         timestamp_with_highest_adc = timestamp;
       }
       timestamp++;
-      adc_histo_map["ROC " + std::to_string(hgcroc_number) + " - ADC"]->Fill(channel, adc_t);
-      tot_histo_map["ROC " + std::to_string(hgcroc_number) + " - TOT"]->Fill(channel, tot);
-      toa_histo_map["ROC " + std::to_string(hgcroc_number) + " - TOA"]->Fill(channel, toa);
+      adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(hgcroc_number) + " - ADC"]->Fill(channel, adc_t);
+      tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(hgcroc_number) + " - TOT"]->Fill(channel, tot);
+      toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(hgcroc_number) + " - TOA"]->Fill(channel, toa);
       //std::cout<<"isTOT: "<<isTOT<<"  isTOTComplete: "<<isTOTComplete<<"  toa: "<<toa<<"  tot: "<<tot<<"  adc_tm1: "<<adc_tm1<<"  adc_t "<<adc_t<<std::endl;
     }
-    max_sample_histo_map["ROC " + std::to_string(hgcroc_number) + " - max_sample"]->Fill(channel, timestamp_with_highest_adc);
+    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(hgcroc_number) + " - max_sample"]->Fill(channel, timestamp_with_highest_adc);
 
 
-    double threshold = adcped + mV_per_PE / adcgain * threshold_PE; 
+    //double threshold = adcped + mV_per_PE / adcgain * threshold_PE;
+    double threshold = adcped + 20; //hard-coded for now
     if(maxadc >= threshold){
       if(end != 0){
         hcalhits_top->Fill(plane, barchan);
@@ -195,7 +197,7 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
         hcalhits_bot->Fill(plane, barchan);
       }
     }
-    double PE_chan = (maxadc - adcped) / mV_per_PE * adcgain; 
+    double PE_chan = (maxadc - adcped) / mV_per_PE * adcgain;
     PE = PE + PE_chan;
     if(PE_chan < 0) PE_chan = 0;
     physical_map.insert(std::pair<std::string, double>(location, PE_chan));

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -189,7 +189,9 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
 
     //double threshold = adcped + mV_per_PE / adcgain * threshold_PE;
     double threshold = adcped + 20; //hard-coded for now
+    int isAboveThreshold = 0;
     if(maxadc >= threshold){
+      isAboveThreshold = 1;
       if(end != 0){
         hcalhits_top->Fill(plane, barchan);
       }
@@ -197,17 +199,18 @@ void HCalTestBeamMonitor::AtEventReception(EventSP event) {
         hcalhits_bot->Fill(plane, barchan);
       }
     }
-    double PE_chan = (maxadc - adcped) / mV_per_PE * adcgain;
-    PE = PE + PE_chan;
-    if(PE_chan < 0) PE_chan = 0;
-    physical_map.insert(std::pair<std::string, double>(location, PE_chan));
+    //double PE_chan = (maxadc - adcped) / mV_per_PE * adcgain;
+    //PE = PE + PE_chan;
+    //if(PE_chan < 0) PE_chan = 0;
+    //physical_map.insert(std::pair<std::string, double>(location, PE_chan));
+    physical_map.insert(std::pair<std::string, double>(location, isAboveThreshold));
   }
-  total_PE->Fill(PE);
+  //total_PE->Fill(PE);
   for(int i = 1; i < nPlanes+1; i++){
     for(int j = 0; j < 12; j++){
       std::string key0 = std::to_string(i) + ":" + std::to_string(j) + ":0";
       std::string key1 = std::to_string(i) + ":" + std::to_string(j) + ":1";
-      double PEsum = 0;
+      //double PEsum = 0;
       if(physical_map.count(key0) > 0 && physical_map.count(key1) > 0){
         PEsum = physical_map.at(key0) + physical_map.at(key1);
       }

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.cxx
@@ -34,7 +34,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
                               "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_ADC", "",
                               ";Channel;ADC", 72, 0, 72, 1024, 0, 1024);
     m_monitor->SetDrawOptions(adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"], "colz");
-    adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"]->SetTitle(("ADC vs Channel, FPGA " + std::to_string(_block) +": ROC " + std::to_string(i)).c_str());
+    adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"]->SetTitle(("ADC vs Channel, FPGA " + std::to_string(block_) +": ROC " + std::to_string(i)).c_str());
     adc_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - ADC"]->SetStats(0);
 
     tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"] =
@@ -42,7 +42,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
                               "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_TOT", "",
                               ";Channel;TOT", 72, 0, 72, 1024, 0, 1024);
     m_monitor->SetDrawOptions(tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"], "colz");
-    tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"]->SetTitle(("TOT vs Channel, FPGA " + std::to_string(_block) +": ROC " + std::to_string(i)).c_str());
+    tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"]->SetTitle(("TOT vs Channel, FPGA " + std::to_string(block_) +": ROC " + std::to_string(i)).c_str());
     tot_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOT"]->SetStats(0);
 
     toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"] =
@@ -50,7 +50,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
                               "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_TOA", "",
                               ";Channel;TOA", 72, 0, 72, 1024, 0, 1024);
     m_monitor->SetDrawOptions(toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"], "colz");
-    toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"]->SetTitle(("TOA vs Channel, FPGA " + std::to_string(_block) + ": ROC " + std::to_string(i)).c_str());
+    toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"]->SetTitle(("TOA vs Channel, FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i)).c_str());
     toa_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - TOA"]->SetStats(0);
 
     //hardcoded 8 time samples
@@ -59,7 +59,7 @@ void HCalTestBeamMonitor::AtConfiguration() {
                               "FPGA " + std::to_string(block_) + "_ROC_" + std::to_string(i) + "_max_sample", "",
                               ";Channel;max_sample", 72, 0, 72, 8, 0, 8);
     m_monitor->SetDrawOptions(max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"], "colz");
-    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"]->SetTitle(("max_sample vs Channel, FPGA " + std::to_string(_block) + ": ROC " + std::to_string(i)).c_str());
+    max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"]->SetTitle(("max_sample vs Channel, FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i)).c_str());
     max_sample_histo_map["FPGA " + std::to_string(block_) + ": ROC " + std::to_string(i) + " - max_sample"]->SetStats(0);
   }
 

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.h
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.h
@@ -37,6 +37,7 @@ private:
   TH2D* hcalhits_top; 
   TH2D* hcalhits_bot; 
   TH1D* total_PE; 
+  TH2D* hcal_event;
   
   std::map<std::string, int> cmb_map;
   std::map<std::string, int> quadbar_map;
@@ -49,8 +50,10 @@ private:
   std::map<std::string, double> totped_map;
   std::map<std::string, double> totgain_map;
 
-  int nPlanes;
   std::vector<int> unusedchans;
+  int nPlanes;
+  int nevents_reset;
+  int nevents;
   
   double threshold_PE; //aribtrary for now
   double energy_per_mip; //MeV/MIP

--- a/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.h
+++ b/software/eudaq/src/eudaq/monitor/HCalTestBeamMonitor.h
@@ -19,11 +19,11 @@ public:
 
   ~HCalTestBeamMonitor() = default;
 
-  void AtConfiguration() override; 
-  void AtEventReception(eudaq::EventSP ev) override; 
+  void AtConfiguration() override;
+  void AtEventReception(eudaq::EventSP ev) override;
 
   static const uint32_t factory_id_{eudaq::cstr2hash("HCalTestBeamMonitor")};
-  
+
 private:
   int getField(int value, int high_bit, int low_bit) {
     int mask{static_cast<int>(pow(2, (high_bit - low_bit + 1)) - 1)};
@@ -32,13 +32,13 @@ private:
   int block_;
   std::map<std::string, TH2D*> adc_histo_map;
   std::map<std::string, TH2D*> tot_histo_map;
-  std::map<std::string, TH2D*> toa_histo_map; 
-  std::map<std::string, TH2D*> max_sample_histo_map; 
-  TH2D* hcalhits_top; 
-  TH2D* hcalhits_bot; 
-  TH1D* total_PE; 
+  std::map<std::string, TH2D*> toa_histo_map;
+  std::map<std::string, TH2D*> max_sample_histo_map;
+  TH2D* hcalhits_top;
+  TH2D* hcalhits_bot;
+  //TH1D* total_PE; 
   TH2D* hcal_event;
-  
+
   std::map<std::string, int> cmb_map;
   std::map<std::string, int> quadbar_map;
   std::map<std::string, int> bar_map;
@@ -54,7 +54,7 @@ private:
   int nPlanes;
   int nevents_reset;
   int nevents;
-  
+
   double threshold_PE; //aribtrary for now
   double energy_per_mip; //MeV/MIP
   double voltage_hcal; //mV/PE


### PR DESCRIPTION
- Update plots for only 3 rocs per browser (one browser per pf)
- Add event display plot to the standard HCal monitoring (the separate event display monitor is no longer needed)
- Hack a threshold to start for the first run.