### PR TITLE
start/stop polarfire target so pftool can be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __pycache__
 .ipynb_checkpoints
 
 *.root
+config*.txt

--- a/software/eudaq/CMakeLists.txt
+++ b/software/eudaq/CMakeLists.txt
@@ -95,7 +95,7 @@ if (pflib_FOUND)
   symlink_to_eudaq(pflib)
   install(TARGETS eudaq_pflib DESTINATION lib)
 else()
-  message(WARNING "pflib version >= 2 not found - PolarfireProducer will not be available.")
+  message(WARNING "pflib version >= 2.5 not found - PolarfireProducer will not be available.")
 endif()
 
 option(BUILD_MONITORING "Build online monitoring based off ROOT and EUDAQ" ON)

--- a/software/eudaq/CMakeLists.txt
+++ b/software/eudaq/CMakeLists.txt
@@ -87,7 +87,7 @@ else()
   message(WARNING "Unable to find FiberTrackerClient.h or Dip.h - DipClientProducer will not be built.")
 endif()
 
-find_package(pflib 2.4 QUIET)
+find_package(pflib 2.5 QUIET)
 if (pflib_FOUND)
   add_library(eudaq_pflib SHARED
     src/eudaq/pflib/PolarfireProducer.cxx)


### PR DESCRIPTION
With the newest release of pflib [v2.5](https://github.com/LDMX-Software/pflib/releases/tag/v2.5.0), I was able to make the changes necessary to allow users to use pftool during the "uninitialized" run control state.